### PR TITLE
Fix issue with array_key_exists function

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 CHIP SDN. BHD.
+Copyright (c) 2025 CHIP SDN. BHD.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,12 @@
 == Changelog ==
 
+= 1.6.0 2025-07-17 =
+* Improved - All uses of array_key_exists now safely check is_array to prevent errors
+* Improved - Invoice ID validation now uses filter_var for better security and correctness
+* Improved - Consistent error handling and input validation across all gateway and callback files
+* Fixed - Potential issues with null or non-array API responses
+* Security - Recommended enabling SSL verification for all API calls
+
 = 1.5.1 2025-03-26 =
 * Fixed - Issue with transaction information error when loading popup
 * Fixed - Issue with timezone not reflecting Asia/Kuala_Lumpur time

--- a/modules/gateways/callback/chip.php
+++ b/modules/gateways/callback/chip.php
@@ -18,8 +18,10 @@ if (!isset($_SERVER['HTTP_X_SIGNATURE'])) {
   die('No X Signature received from headers');
 }
 
-if (empty($get_invoice_id = intval($_GET['invoiceid']))) {
-  die('invoiceid parameter is empty');
+// In redirect files, validate invoice ID
+$get_invoice_id = filter_var($_GET['invoiceid'], FILTER_VALIDATE_INT);
+if (!$get_invoice_id || $get_invoice_id <= 0) {
+    die('Invalid invoice ID');
 }
 
 $gatewayParams = getGatewayVariables('chip');

--- a/modules/gateways/callback/chip_cards.php
+++ b/modules/gateways/callback/chip_cards.php
@@ -18,8 +18,10 @@ if (!isset($_SERVER['HTTP_X_SIGNATURE'])) {
   die('No X Signature received from headers');
 }
 
-if (empty($get_invoice_id = intval($_GET['invoiceid']))) {
-  die('invoiceid parameter is empty');
+// In redirect files, validate invoice ID
+$get_invoice_id = filter_var($_GET['invoiceid'], FILTER_VALIDATE_INT);
+if (!$get_invoice_id || $get_invoice_id <= 0) {
+    die('Invalid invoice ID');
 }
 
 $gatewayParams = getGatewayVariables('chip_cards');

--- a/modules/gateways/callback/chip_dnqr.php
+++ b/modules/gateways/callback/chip_dnqr.php
@@ -18,8 +18,10 @@ if (!isset($_SERVER['HTTP_X_SIGNATURE'])) {
   die('No X Signature received from headers');
 }
 
-if (empty($get_invoice_id = intval($_GET['invoiceid']))) {
-  die('invoiceid parameter is empty');
+// In redirect files, validate invoice ID
+$get_invoice_id = filter_var($_GET['invoiceid'], FILTER_VALIDATE_INT);
+if (!$get_invoice_id || $get_invoice_id <= 0) {
+    die('Invalid invoice ID');
 }
 
 $gatewayParams = getGatewayVariables('chip_dnqr');

--- a/modules/gateways/callback/chip_ewallets.php
+++ b/modules/gateways/callback/chip_ewallets.php
@@ -18,8 +18,10 @@ if (!isset($_SERVER['HTTP_X_SIGNATURE'])) {
   die('No X Signature received from headers');
 }
 
-if (empty($get_invoice_id = intval($_GET['invoiceid']))) {
-  die('invoiceid parameter is empty');
+// In redirect files, validate invoice ID
+$get_invoice_id = filter_var($_GET['invoiceid'], FILTER_VALIDATE_INT);
+if (!$get_invoice_id || $get_invoice_id <= 0) {
+    die('Invalid invoice ID');
 }
 
 $gatewayParams = getGatewayVariables('chip_ewallets');

--- a/modules/gateways/callback/chip_fpx.php
+++ b/modules/gateways/callback/chip_fpx.php
@@ -18,8 +18,10 @@ if (!isset($_SERVER['HTTP_X_SIGNATURE'])) {
   die('No X Signature received from headers');
 }
 
-if (empty($get_invoice_id = intval($_GET['invoiceid']))) {
-  die('invoiceid parameter is empty');
+// In redirect files, validate invoice ID
+$get_invoice_id = filter_var($_GET['invoiceid'], FILTER_VALIDATE_INT);
+if (!$get_invoice_id || $get_invoice_id <= 0) {
+    die('Invalid invoice ID');
 }
 
 $gatewayParams = getGatewayVariables('chip_fpx');

--- a/modules/gateways/callback/chip_fpxb2b1.php
+++ b/modules/gateways/callback/chip_fpxb2b1.php
@@ -18,8 +18,10 @@ if (!isset($_SERVER['HTTP_X_SIGNATURE'])) {
   die('No X Signature received from headers');
 }
 
-if (empty($get_invoice_id = intval($_GET['invoiceid']))) {
-  die('invoiceid parameter is empty');
+// In redirect files, validate invoice ID
+$get_invoice_id = filter_var($_GET['invoiceid'], FILTER_VALIDATE_INT);
+if (!$get_invoice_id || $get_invoice_id <= 0) {
+    die('Invalid invoice ID');
 }
 
 $gatewayParams = getGatewayVariables('chip_fpxb2b1');

--- a/modules/gateways/chip.php
+++ b/modules/gateways/chip.php
@@ -286,7 +286,7 @@ function chip_refund($params)
   $chip = \ChipAPI::get_instance($params['secretKey'], $params['brandId']);
   $result = $chip->refund_payment($params['transid'], array('amount' => round($params['amount'] * 100)));
 
-  if (!array_key_exists('id', $result) or $result['status'] != 'success') {
+  if (!is_array($result) || !array_key_exists('id', $result) or $result['status'] != 'success') {
     return array(
       'status' => 'error',
       'rawdata' => json_encode($result),
@@ -327,7 +327,7 @@ function chip_TransactionInformation(array $params = []): Information
   $payment = $chip->get_payment($params['transactionId']);
   $information = new Information();
 
-  if (array_key_exists('__all__', $payment)) {
+  if (!is_array($payment) || array_key_exists('__all__', $payment)) {
     return $information;
   }
 

--- a/modules/gateways/chip.php
+++ b/modules/gateways/chip.php
@@ -50,7 +50,7 @@ function chip_config($params = array())
     $chip = \ChipAPI::get_instance($params['secretKey'], $params['brandId']);
     $result = $chip->payment_methods('MYR');
 
-    if (array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
+    if (is_array($result) && array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
       foreach ($result['available_payment_methods'] as $apm) {
         $available_payment_method['payment_method_whitelist__' . $apm] = array(
           'FriendlyName' => 'Whitelist ' . ucfirst($apm),
@@ -64,7 +64,7 @@ function chip_config($params = array())
 
     $result = $chip->payment_recurring_methods('MYR');
 
-    if (array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
+    if (is_array($result) && array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
       $show_force_token_option = true;
     }
   }

--- a/modules/gateways/chip/api.php
+++ b/modules/gateways/chip/api.php
@@ -168,7 +168,7 @@ class ChipAPI
       curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PATCH');
     }
 
-    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     curl_setopt($ch, CURLOPT_FRESH_CONNECT, 1);
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);

--- a/modules/gateways/chip/redirect.php
+++ b/modules/gateways/chip/redirect.php
@@ -14,11 +14,11 @@ if (!isset($_GET['invoiceid'])) {
   exit;
 }
 
-$get_invoice_id = intval($_GET['invoiceid']);
-
-if (empty($get_invoice_id)) {
-  header('Location: ' . $CONFIG['SystemURL']);
-  exit;
+// In redirect files, validate invoice ID
+$get_invoice_id = filter_var($_GET['invoiceid'], FILTER_VALIDATE_INT);
+if (!$get_invoice_id || $get_invoice_id <= 0) {
+    header('Location: ' . $CONFIG['SystemURL']);
+    exit;
 }
 
 $invoice = new Invoice($get_invoice_id);

--- a/modules/gateways/chip/redirect.php
+++ b/modules/gateways/chip/redirect.php
@@ -116,7 +116,7 @@ $chip = \ChipAPI::get_instance($params['secretKey'], $params['brandId']);
 
 $get_client = $chip->get_client_by_email($params['clientdetails']['email']);
 
-if (array_key_exists('__all__', $get_client)) {
+if (is_array($get_client) && array_key_exists('__all__', $get_client)) {
   throw new Exception('Failed to create purchase. Errors: ' . print_r($get_client, true));
 }
 
@@ -135,7 +135,7 @@ $send_params['client_id'] = $client['id'];
 
 $payment = $chip->create_payment($send_params);
 
-if (!array_key_exists('id', $payment)) {
+if (!is_array($payment) || !array_key_exists('id', $payment)) {
   throw new Exception('Failed to create purchase. Errors: ' . print_r($payment, true));
 }
 

--- a/modules/gateways/chip/redirect.php
+++ b/modules/gateways/chip/redirect.php
@@ -116,7 +116,7 @@ $chip = \ChipAPI::get_instance($params['secretKey'], $params['brandId']);
 
 $get_client = $chip->get_client_by_email($params['clientdetails']['email']);
 
-if (is_array($get_client) && array_key_exists('__all__', $get_client)) {
+if (!is_array($get_client) || array_key_exists('__all__', $get_client)) {
   throw new Exception('Failed to create purchase. Errors: ' . print_r($get_client, true));
 }
 

--- a/modules/gateways/chip/redirect.php
+++ b/modules/gateways/chip/redirect.php
@@ -120,7 +120,7 @@ if (array_key_exists('__all__', $get_client)) {
   throw new Exception('Failed to create purchase. Errors: ' . print_r($get_client, true));
 }
 
-if (is_array($get_client['results']) and !empty($get_client['results'])) {
+if (!empty($get_client['results']) && is_array($get_client['results'])) {
   $client = $get_client['results'][0];
 
   if ($params['updateClientInfo'] == 'on') {

--- a/modules/gateways/chip_cards.php
+++ b/modules/gateways/chip_cards.php
@@ -69,7 +69,7 @@ function chip_cards_config($params = array())
       ]
     ];
 
-    if (array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
+    if (is_array($result) && array_key_exists('available_payment_methods', $result) && !empty($result['available_payment_methods'])) {
       foreach ($result['available_payment_methods'] as $apm) {
 
 
@@ -103,7 +103,7 @@ function chip_cards_config($params = array())
       ]
     ];
 
-    if (array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
+    if (is_array($result) && array_key_exists('available_payment_methods', $result) && !empty($result['available_payment_methods'])) {
       $show_force_token_option = true;
     }
   }

--- a/modules/gateways/chip_cards.php
+++ b/modules/gateways/chip_cards.php
@@ -266,7 +266,7 @@ function chip_cards_refund($params)
   $chip = \ChipAPI::get_instance($params['secretKey'], $params['brandId']);
   $result = $chip->refund_payment($params['transid'], array('amount' => round($params['amount'] * 100)));
 
-  if (!array_key_exists('id', $result) or $result['status'] != 'success') {
+  if (!is_array($result) || !array_key_exists('id', $result) or $result['status'] != 'success') {
     return array(
       'status' => 'error',
       'rawdata' => json_encode($result),
@@ -307,7 +307,7 @@ function chip_cards_TransactionInformation(array $params = []): Information
   $payment = $chip->get_payment($params['transactionId']);
   $information = new Information();
 
-  if (array_key_exists('__all__', $payment)) {
+  if (!is_array($payment) || array_key_exists('__all__', $payment)) {
     return $information;
   }
 

--- a/modules/gateways/chip_cards/redirect.php
+++ b/modules/gateways/chip_cards/redirect.php
@@ -14,11 +14,11 @@ if ( !isset($_GET['invoiceid']) ) {
   exit;
 }
 
-$get_invoice_id  = intval($_GET['invoiceid']);
-
-if ( empty($get_invoice_id) ) {
-  header( 'Location: ' . $CONFIG['SystemURL'] );
-  exit;
+// In redirect files, validate invoice ID
+$get_invoice_id = filter_var($_GET['invoiceid'], FILTER_VALIDATE_INT);
+if (!$get_invoice_id || $get_invoice_id <= 0) {
+    header('Location: ' . $CONFIG['SystemURL']);
+    exit;
 }
 
 $invoice = new Invoice($get_invoice_id);

--- a/modules/gateways/chip_cards/redirect.php
+++ b/modules/gateways/chip_cards/redirect.php
@@ -112,11 +112,11 @@ $chip    = \ChipAPI::get_instance( $params['secretKey'], $params['brandId'] );
 
 $get_client = $chip->get_client_by_email($params['clientdetails']['email']);
 
-if (array_key_exists('__all__', $get_client)) {
+if (!is_array($get_client) || array_key_exists('__all__', $get_client)) {
   throw new Exception( 'Failed to create purchase. Errors: ' . print_r($get_client, true) ) ;
 }
 
-if (is_array($get_client['results']) AND !empty($get_client['results'])) {
+if (!empty($get_client['results']) && is_array($get_client['results'])) {
   $client = $get_client['results'][0];
 
   if ($params['updateClientInfo'] == 'on') {

--- a/modules/gateways/chip_cards/redirect.php
+++ b/modules/gateways/chip_cards/redirect.php
@@ -131,7 +131,7 @@ $send_params['client_id'] = $client['id'];
 
 $payment = $chip->create_payment( $send_params );
 
-if ( !array_key_exists('id', $payment) ) {
+if ( !is_array($payment) || !array_key_exists('id', $payment) ) {
   throw new Exception( 'Failed to create purchase. Errors: ' . print_r($payment, true) ) ;
 }
 

--- a/modules/gateways/chip_dnqr.php
+++ b/modules/gateways/chip_dnqr.php
@@ -69,7 +69,7 @@ function chip_dnqr_config($params = array())
       ]
     ];
 
-    if (array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
+    if (is_array($result) && array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
       foreach ($result['available_payment_methods'] as $apm) {
 
 
@@ -95,7 +95,7 @@ function chip_dnqr_config($params = array())
 
     $result = $chip->payment_recurring_methods('MYR');
 
-    if (array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
+    if (is_array($result) && array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
       $show_force_token_option = true;
     }
   }

--- a/modules/gateways/chip_dnqr.php
+++ b/modules/gateways/chip_dnqr.php
@@ -258,7 +258,7 @@ function chip_dnqr_refund($params)
   $chip = \ChipAPI::get_instance($params['secretKey'], $params['brandId']);
   $result = $chip->refund_payment($params['transid'], array('amount' => round($params['amount'] * 100)));
 
-  if (!array_key_exists('id', $result) or $result['status'] != 'success') {
+  if (!is_array($result) || !array_key_exists('id', $result) or $result['status'] != 'success') {
     return array(
       'status' => 'error',
       'rawdata' => json_encode($result),
@@ -299,7 +299,7 @@ function chip_dnqr_TransactionInformation(array $params = []): Information
   $payment = $chip->get_payment($params['transactionId']);
   $information = new Information();
 
-  if (array_key_exists('__all__', $payment)) {
+  if (!is_array($payment) || array_key_exists('__all__', $payment)) {
     return $information;
   }
 

--- a/modules/gateways/chip_dnqr/redirect.php
+++ b/modules/gateways/chip_dnqr/redirect.php
@@ -113,11 +113,11 @@ $chip = \ChipAPI::get_instance($params['secretKey'], $params['brandId']);
 
 $get_client = $chip->get_client_by_email($params['clientdetails']['email']);
 
-if (array_key_exists('__all__', $get_client)) {
+if (!is_array($get_client) || array_key_exists('__all__', $get_client)) {
   throw new Exception('Failed to create purchase. Errors: ' . print_r($get_client, true));
 }
 
-if (is_array($get_client['results']) and !empty($get_client['results'])) {
+if (!empty($get_client['results']) && is_array($get_client['results'])) {
   $client = $get_client['results'][0];
 
   if ($params['updateClientInfo'] == 'on') {

--- a/modules/gateways/chip_dnqr/redirect.php
+++ b/modules/gateways/chip_dnqr/redirect.php
@@ -14,11 +14,11 @@ if (!isset($_GET['invoiceid'])) {
   exit;
 }
 
-$get_invoice_id = intval($_GET['invoiceid']);
-
-if (empty($get_invoice_id)) {
-  header('Location: ' . $CONFIG['SystemURL']);
-  exit;
+// In redirect files, validate invoice ID
+$get_invoice_id = filter_var($_GET['invoiceid'], FILTER_VALIDATE_INT);
+if (!$get_invoice_id || $get_invoice_id <= 0) {
+    header('Location: ' . $CONFIG['SystemURL']);
+    exit;
 }
 
 $invoice = new Invoice($get_invoice_id);

--- a/modules/gateways/chip_dnqr/redirect.php
+++ b/modules/gateways/chip_dnqr/redirect.php
@@ -132,7 +132,7 @@ $send_params['client_id'] = $client['id'];
 
 $payment = $chip->create_payment($send_params);
 
-if (!array_key_exists('id', $payment)) {
+if (!is_array($payment) || !array_key_exists('id', $payment)) {
   throw new Exception('Failed to create purchase. Errors: ' . print_r($payment, true));
 }
 

--- a/modules/gateways/chip_ewallets.php
+++ b/modules/gateways/chip_ewallets.php
@@ -69,7 +69,7 @@ function chip_ewallets_config($params = array())
       ]
     ];
 
-    if (array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
+    if (is_array($result) && array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
       foreach ($result['available_payment_methods'] as $apm) {
 
 
@@ -103,7 +103,7 @@ function chip_ewallets_config($params = array())
       ]
     ];
 
-    if (array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
+    if (is_array($result) && array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
       $show_force_token_option = true;
     }
   }
@@ -266,7 +266,7 @@ function chip_ewallets_refund($params)
   $chip = \ChipAPI::get_instance($params['secretKey'], $params['brandId']);
   $result = $chip->refund_payment($params['transid'], array('amount' => round($params['amount'] * 100)));
 
-  if (!array_key_exists('id', $result) or $result['status'] != 'success') {
+  if (!is_array($result) || !array_key_exists('id', $result) or $result['status'] != 'success') {
     return array(
       'status' => 'error',
       'rawdata' => json_encode($result),
@@ -307,7 +307,7 @@ function chip_ewallets_TransactionInformation(array $params = []): Information
   $payment = $chip->get_payment($params['transactionId']);
   $information = new Information();
 
-  if (array_key_exists('__all__', $payment)) {
+  if (!is_array($payment) || array_key_exists('__all__', $payment)) {
     return $information;
   }
 

--- a/modules/gateways/chip_ewallets/redirect.php
+++ b/modules/gateways/chip_ewallets/redirect.php
@@ -14,11 +14,11 @@ if ( !isset($_GET['invoiceid']) ) {
   exit;
 }
 
-$get_invoice_id  = intval($_GET['invoiceid']);
-
-if ( empty($get_invoice_id) ) {
-  header( 'Location: ' . $CONFIG['SystemURL'] );
-  exit;
+// In redirect files, validate invoice ID
+$get_invoice_id = filter_var($_GET['invoiceid'], FILTER_VALIDATE_INT);
+if (!$get_invoice_id || $get_invoice_id <= 0) {
+    header('Location: ' . $CONFIG['SystemURL']);
+    exit;
 }
 
 $invoice = new Invoice($get_invoice_id);

--- a/modules/gateways/chip_ewallets/redirect.php
+++ b/modules/gateways/chip_ewallets/redirect.php
@@ -130,7 +130,7 @@ $send_params['client_id'] = $client['id'];
 
 $payment = $chip->create_payment( $send_params );
 
-if ( !array_key_exists('id', $payment) ) {
+if ( !is_array($payment) || !array_key_exists('id', $payment) ) {
   throw new Exception( 'Failed to create purchase. Errors: ' . print_r($payment, true) ) ;
 }
 

--- a/modules/gateways/chip_ewallets/redirect.php
+++ b/modules/gateways/chip_ewallets/redirect.php
@@ -111,11 +111,11 @@ $chip    = \ChipAPI::get_instance( $params['secretKey'], $params['brandId'] );
 
 $get_client = $chip->get_client_by_email($params['clientdetails']['email']);
 
-if (array_key_exists('__all__', $get_client)) {
+if (!is_array($get_client) || array_key_exists('__all__', $get_client)) {
   throw new Exception( 'Failed to create purchase. Errors: ' . print_r($get_client, true) ) ;
 }
 
-if (is_array($get_client['results']) AND !empty($get_client['results'])) {
+if (!empty($get_client['results']) && is_array($get_client['results'])) {
   $client = $get_client['results'][0];
 
   if ($params['updateClientInfo'] == 'on') {

--- a/modules/gateways/chip_fpx.php
+++ b/modules/gateways/chip_fpx.php
@@ -69,7 +69,7 @@ function chip_fpx_config($params = array())
       ]
     ];
 
-    if (array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
+    if (is_array($result) && array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
       foreach ($result['available_payment_methods'] as $apm) {
 
 
@@ -103,7 +103,7 @@ function chip_fpx_config($params = array())
       ]
     ];
 
-    if (array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
+    if (is_array($result) && array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
       $show_force_token_option = true;
     }
   }
@@ -266,7 +266,7 @@ function chip_fpx_refund($params)
   $chip = \ChipAPI::get_instance($params['secretKey'], $params['brandId']);
   $result = $chip->refund_payment($params['transid'], array('amount' => round($params['amount'] * 100)));
 
-  if (!array_key_exists('id', $result) or $result['status'] != 'success') {
+  if (!is_array($result) || !array_key_exists('id', $result) or $result['status'] != 'success') {
     return array(
       'status' => 'error',
       'rawdata' => json_encode($result),
@@ -307,7 +307,7 @@ function chip_fpx_TransactionInformation(array $params = []): Information
   $payment = $chip->get_payment($params['transactionId']);
   $information = new Information();
 
-  if (array_key_exists('__all__', $payment)) {
+  if (!is_array($payment) || array_key_exists('__all__', $payment)) {
     return $information;
   }
 

--- a/modules/gateways/chip_fpx/redirect.php
+++ b/modules/gateways/chip_fpx/redirect.php
@@ -113,11 +113,11 @@ $chip = \ChipAPI::get_instance($params['secretKey'], $params['brandId']);
 
 $get_client = $chip->get_client_by_email($params['clientdetails']['email']);
 
-if (array_key_exists('__all__', $get_client)) {
+if (!is_array($get_client) || array_key_exists('__all__', $get_client)) {
   throw new Exception('Failed to create purchase. Errors: ' . print_r($get_client, true));
 }
 
-if (is_array($get_client['results']) and !empty($get_client['results'])) {
+if (!empty($get_client['results']) && is_array($get_client['results'])) {
   $client = $get_client['results'][0];
 
   if ($params['updateClientInfo'] == 'on') {

--- a/modules/gateways/chip_fpx/redirect.php
+++ b/modules/gateways/chip_fpx/redirect.php
@@ -14,11 +14,11 @@ if (!isset($_GET['invoiceid'])) {
   exit;
 }
 
-$get_invoice_id = intval($_GET['invoiceid']);
-
-if (empty($get_invoice_id)) {
-  header('Location: ' . $CONFIG['SystemURL']);
-  exit;
+// In redirect files, validate invoice ID
+$get_invoice_id = filter_var($_GET['invoiceid'], FILTER_VALIDATE_INT);
+if (!$get_invoice_id || $get_invoice_id <= 0) {
+    header('Location: ' . $CONFIG['SystemURL']);
+    exit;
 }
 
 $invoice = new Invoice($get_invoice_id);

--- a/modules/gateways/chip_fpx/redirect.php
+++ b/modules/gateways/chip_fpx/redirect.php
@@ -132,7 +132,7 @@ $send_params['client_id'] = $client['id'];
 
 $payment = $chip->create_payment($send_params);
 
-if (!array_key_exists('id', $payment)) {
+if (!is_array($payment) || !array_key_exists('id', $payment)) {
   throw new Exception('Failed to create purchase. Errors: ' . print_r($payment, true));
 }
 

--- a/modules/gateways/chip_fpxb2b1.php
+++ b/modules/gateways/chip_fpxb2b1.php
@@ -69,7 +69,7 @@ function chip_fpxb2b1_config($params = array())
       ]
     ];
 
-    if (array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
+    if (is_array($result) && array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
       foreach ($result['available_payment_methods'] as $apm) {
 
 
@@ -103,7 +103,7 @@ function chip_fpxb2b1_config($params = array())
       ]
     ];
 
-    if (array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
+    if (is_array($result) && array_key_exists('available_payment_methods', $result) and !empty($result['available_payment_methods'])) {
       $show_force_token_option = true;
     }
   }
@@ -266,7 +266,7 @@ function chip_fpxb2b1_refund($params)
   $chip = \ChipAPI::get_instance($params['secretKey'], $params['brandId']);
   $result = $chip->refund_payment($params['transid'], array('amount' => round($params['amount'] * 100)));
 
-  if (!array_key_exists('id', $result) or $result['status'] != 'success') {
+  if (!is_array($result) || !array_key_exists('id', $result) or $result['status'] != 'success') {
     return array(
       'status' => 'error',
       'rawdata' => json_encode($result),
@@ -307,7 +307,7 @@ function chip_fpxb2b1_TransactionInformation(array $params = []): Information
   $payment = $chip->get_payment($params['transactionId']);
   $information = new Information();
 
-  if (array_key_exists('__all__', $payment)) {
+  if (!is_array($payment) || array_key_exists('__all__', $payment)) {
     return $information;
   }
 

--- a/modules/gateways/chip_fpxb2b1/redirect.php
+++ b/modules/gateways/chip_fpxb2b1/redirect.php
@@ -113,11 +113,11 @@ $chip = \ChipAPI::get_instance($params['secretKey'], $params['brandId']);
 
 $get_client = $chip->get_client_by_email($params['clientdetails']['email']);
 
-if (array_key_exists('__all__', $get_client)) {
+if (!is_array($get_client) || array_key_exists('__all__', $get_client)) {
   throw new Exception('Failed to create purchase. Errors: ' . print_r($get_client, true));
 }
 
-if (is_array($get_client['results']) and !empty($get_client['results'])) {
+if (!empty($get_client['results']) && is_array($get_client['results'])) {
   $client = $get_client['results'][0];
 
   if ($params['updateClientInfo'] == 'on') {

--- a/modules/gateways/chip_fpxb2b1/redirect.php
+++ b/modules/gateways/chip_fpxb2b1/redirect.php
@@ -14,11 +14,11 @@ if (!isset($_GET['invoiceid'])) {
   exit;
 }
 
-$get_invoice_id = intval($_GET['invoiceid']);
-
-if (empty($get_invoice_id)) {
-  header('Location: ' . $CONFIG['SystemURL']);
-  exit;
+// In redirect files, validate invoice ID
+$get_invoice_id = filter_var($_GET['invoiceid'], FILTER_VALIDATE_INT);
+if (!$get_invoice_id || $get_invoice_id <= 0) {
+    header('Location: ' . $CONFIG['SystemURL']);
+    exit;
 }
 
 $invoice = new Invoice($get_invoice_id);

--- a/modules/gateways/chip_fpxb2b1/redirect.php
+++ b/modules/gateways/chip_fpxb2b1/redirect.php
@@ -132,7 +132,7 @@ $send_params['client_id'] = $client['id'];
 
 $payment = $chip->create_payment($send_params);
 
-if (!array_key_exists('id', $payment)) {
+if (!is_array($payment) || !array_key_exists('id', $payment)) {
   throw new Exception('Failed to create purchase. Errors: ' . print_r($payment, true));
 }
 


### PR DESCRIPTION
## What does this change?
This release fix issue with array_key_exists function. Some value returned `null` instead of empty array. Hence, using array_key_exists without checking `is_array` cause error.

## Asana / Jira / Trello task link
[Asana](https://app.asana.com/1/1203390264907019/project/1203417845528369/task/1210818382556134?focus=true)

## How to test

1. Set invalid secret key in CHIP payment method. It shouldn't return error after save and refresh.
2. Make a payment (full journey) and order should be updated properly in both redirect and callback.